### PR TITLE
Comment invalid key

### DIFF
--- a/grammars/typelanguage.tmLanguage.json
+++ b/grammars/typelanguage.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	// "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "Type Language",
 	"patterns": [
 		{


### PR DESCRIPTION
The `$schema` key is detected as invalid by our compiler at [github/linguist](https://github.com/github/linguist), which throws errors during compilation as a result. It looks like the key isn't meant to be parsed, but only read by humans. If that's the case, it can be commented out.

And, yes, Sublime Text JSON supports comments: [modified grammar file in action](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=auto&grammar_url=https%3A%2F%2Fgithub.com%2Fpchaigno%2Flanguage-typelanguage%2Fblob%2Fcomment-invalid-key%2Fgrammars%2Ftypelanguage.tmLanguage.json&grammar_text=&code_source=from-url&code_url=https%3A%2F%2Fgithub.com%2Fgithub%2Flinguist%2Fblob%2Fmaster%2Fsamples%2FType%2520Language%2Fscheme.tl&code=).